### PR TITLE
update interface_to_id to latest metadata format, send iccid to fping_json_formatter

### DIFF
--- a/experiments/ping/files/fping_json_formatter.py
+++ b/experiments/ping/files/fping_json_formatter.py
@@ -15,15 +15,15 @@ import re
 # Set some variables for saving data
 monroe_exporter.initalize('MONROE.EXP.PING', 1, 5.0)
 
-if (len(sys.argv) != 2):
-    print "Usage: {} interface[interfaceName]".format(sys.argv[0])
+if (len(sys.argv) != 3):
+    print "Usage: {} InterfaceName InterfaceId".format(sys.argv[0])
     print "Exiting."
     sys.exit()
 
 interface = sys.argv[1]
+iccid     = sys.argv[2]
 
-print "Using {} ".format(interface)
-
+print "Using {} {}".format(interface, iccid)
 
 # regexp to parse fping output.
 # command: fping -D -p 1000 -l 8.8.8.8
@@ -45,6 +45,7 @@ while line:
     exp_result = m.groupdict()
     msg = {
         'InterfaceName': interface,
+        'ICCID': iccid,
         'Bytes': int(exp_result['bytes']),
         'Host': exp_result['host'],
         'Rtt': float(exp_result['rtt']),

--- a/experiments/ping/files/run.sh
+++ b/experiments/ping/files/run.sh
@@ -14,9 +14,8 @@ if [ ! "$(ip a |grep $IF | grep LOWER_UP)" ]; then
   exit 1
 fi
 
-# FIXME: Need to check that $IF exists, otherwise
-# fping will default to the default route.
-# Add this check after interface_to_id check is enabled, wrap fping in conditional wrapper.
+ICCID=$(python ./interface_to_id.py $IF)
 
-fping -I $IF -D -p 1000 -l 8.8.8.8 | python ./fping_json_formatter.py $IF
-#fping -I $IF -D -p 1000 -l 8.8.8.8 | python ./fping_json_formatter.py $IFID
+echo ICCID
+
+fping -I $IF -D -p 1000 -l 8.8.8.8 | python ./fping_json_formatter.py $IF $ICCID


### PR DESCRIPTION
This code listens on 172.17.0.1 (which is the static IP for the docker bridge) port 5556 (metadata) until a MODEM message arrives with the correct InterfaceName. 
It extracts the ICCID and sends it to the fping_json_formatter as a parameter.

Not thoroughly tested, but roughly how it works. 
TODO: The script should loop if fping fails on ENODEV and the like, and wait to request a new interface ID.
If you do not want to lose experiment data waiting for the Interface ID, you could probably start the ping with the interface name, and the export later once you have an ICCID available. I think this would be easier if you run the fping process and lookup inside python, to monitor the parallel execution.
